### PR TITLE
Changes necessary to support CMake

### DIFF
--- a/.cmake-cxx/CMakeLists.txt
+++ b/.cmake-cxx/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+project(wire-cell-gen-cxx CXX)
+
+if (NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND
+    NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+  message(FATAL_ERROR "Must use either GCC or Clang to build the non-Kokkos components of wire-cell-gen-kokkos.\n"
+    "Using ${CMAKE_CXX_COMPILER_ID}")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS Off)
+
+file(GLOB all_files ${PROJECT_SOURCE_DIR}/../src/*.cxx)
+
+include_directories(SYSTEM $ENV{BOOST_INC})
+
+set(BOOST_ROOT $ENV{BOOST_DIR} )
+set(BOOST_INCLUDEDIR $ENV{BOOST_INC})
+set(BOOST_LIBRARYDIR $ENV{BOOST_LIB})
+set(Boost_USE_MULTITHREADED ON)
+
+find_package(Boost REQUIRED COMPONENTS)
+
+string(APPEND CMAKE_CXX_FLAGS "-g -O3 -pedantic -fopenmp -Wall")
+string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined")
+
+add_library(WireCellGenKokkos_cxx SHARED ${all_files})
+target_include_directories(WireCellGenKokkos_cxx
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/../inc
+    $ENV{EIGEN_INC}
+    $ENV{JSONCPP_INC}
+    $ENV{JSONNET_INC}
+    $ENV{SPDLOG_INC}
+    $ENV{WIRECELL_INC}
+)
+
+target_link_directories(WireCellGenKokkos_cxx PRIVATE $ENV{JSONCPP_LIB} $ENV{WIRECELL_LIB})
+target_link_libraries(WireCellGenKokkos_cxx PRIVATE jsoncpp WireCellIface WireCellUtil Boost::headers)

--- a/.cmake-kokkos/CMakeLists.txt
+++ b/.cmake-kokkos/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+project(wire-cell-gen-kokkos CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS Off)
+
+file(GLOB all_files ${PROJECT_SOURCE_DIR}/../src/*.kokkos)
+
+include_directories(SYSTEM $ENV{BOOST_INC})
+
+set(BOOST_ROOT $ENV{BOOST_DIR} )
+set(BOOST_INCLUDEDIR $ENV{BOOST_INC})
+set(BOOST_LIBRARYDIR $ENV{BOOST_LIB})
+set(Boost_USE_MULTITHREADED ON)
+
+find_package(Boost REQUIRED COMPONENTS)
+find_package(Kokkos REQUIRED)
+
+string(APPEND CMAKE_CXX_FLAGS "-g -O3 -pedantic -Wall")
+string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined")
+
+add_library(WireCellGenKokkos SHARED ${all_files})
+target_include_directories(WireCellGenKokkos
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/../inc
+    $ENV{EIGEN_INC}
+    $ENV{JSONCPP_INC}
+    $ENV{JSONNET_INC}
+    $ENV{SPDLOG_INC}
+    $ENV{WIRECELL_INC}
+)
+set_target_properties(WireCellGenKokkos
+                      PROPERTIES COMPILE_OPTIONS "-DEIGEN_NO_CUDA")
+
+target_link_directories(WireCellGenKokkos PRIVATE $ENV{JSONCPP_LIB} $ENV{WIRECELL_LIB})
+target_link_libraries(WireCellGenKokkos PRIVATE jsoncpp WireCellIface WireCellUtil Boost::headers Kokkos::kokkos)
+
+add_subdirectory(test)

--- a/.cmake-kokkos/test/CMakeLists.txt
+++ b/.cmake-kokkos/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(all_execs
+  test_atadd.kokkos
+  test_random.kokkos
+  test_cuda.kokkos
+)
+
+set(source_dir ${PROJECT_SOURCE_DIR}/../test)
+
+foreach(source_file IN LISTS all_execs)
+  get_filename_component(exec_name ${source_file} NAME_WE)
+  set(renamed_source_file ${CMAKE_CURRENT_BINARY_DIR}/${exec_name}.cpp)
+  configure_file("${source_dir}/${source_file}" ${renamed_source_file} COPYONLY)
+  add_executable(${exec_name} ${renamed_source_file})
+  target_link_libraries(${exec_name} PRIVATE Kokkos::kokkos)
+endforeach()

--- a/build-cmake
+++ b/build-cmake
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+if ! type -p cmake >& /dev/null
+then
+  echo "CMake not available."
+  exit 1
+fi
+
+top_dir="$(cd $(dirname ${BASH_SOURCE[0]}) >&/dev/null && pwd)"
+cmake_dir_cxx=$top_dir/.cmake-cxx
+cmake_dir_kokkos=$top_dir/.cmake-kokkos
+build_dir_cxx=$top_dir/build/cxx
+build_dir_kokkos=$top_dir/build/kokkos
+mkdir -p $build_dir_cxx $build_dir_kokkos
+
+build_cmds="$@"
+
+echo
+echo "======================="
+echo "Building CXX components"
+echo "======================="
+echo
+cd $build_dir_cxx
+[ ! -f Makefile ] && \
+    (cmake $cmake_dir_cxx -DCMAKE_CXX_EXTENSIONS=Off || exit 2)
+make $build_cmds || exit 3
+
+echo
+echo "=========================="
+echo "Building Kokkos components"
+echo "=========================="
+echo
+cd $build_dir_kokkos
+[ ! -f Makefile ] && \
+    (cmake $cmake_dir_kokkos -DCMAKE_CXX_EXTENSIONS=Off -DCMAKE_CXX_COMPILER=$(type -p nvcc_wrapper) || exit 4)
+make $build_cmds || exit 5


### PR DESCRIPTION
This PR introduces support for building with CMake instead of `waftools`.  This came about due to complications encountered while attempting to build on the Cori GPU nodes.  I do not believe the changes introduced here affect the `waftools` support of the package.