### PR TITLE
KokkosEnv

### DIFF
--- a/example/sim.jsonnet
+++ b/example/sim.jsonnet
@@ -125,6 +125,15 @@ local hio_truth = [g.pnode({
     for n in std.range(0, std.length(tools.anodes) - 1)
     ];
 
+local kokkos_test = [g.pnode({
+      type: 'KokkosTestFrameFilter',
+      name: 'kokkos_test%d' % n,
+      data: {
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
 local hio_orig = [g.pnode({
       type: 'HDF5FrameTap',
       name: 'hio_orig%d' % n,
@@ -160,6 +169,7 @@ local reco_fork = [
     g.pipeline([
                 bagger[n],
                 sn_pipes[n],
+                kokkos_test[n],
                 hio_orig[n],
                 // nf_pipes[n],
                 // sp_pipes[n],
@@ -238,7 +248,11 @@ local app = {
   },
 };
 
+local env = {
+    type: "KokkosEnv",
+};
+
 
 // Finally, the configuration sequence which is emitted.
 
-g.uses(graph) + [app]
+[env] + g.uses(graph) + [app]

--- a/inc/WireCellGenKokkos/KokkosEnv.h
+++ b/inc/WireCellGenKokkos/KokkosEnv.h
@@ -2,14 +2,12 @@
 #define WIRECELL_GENKOKKOS_KOKKOSENV
 
 #include "WireCellIface/ITerminal.h"
-#include "WireCellUtil/Logging.h"
 
 namespace WireCell {
     namespace GenKokkos {
         class KokkosEnv : public WireCell::ITerminal {
            private:
             static bool kokkos_initialized;
-            Log::logptr_t log;
 
            public:
             KokkosEnv();

--- a/inc/WireCellGenKokkos/KokkosEnv.h
+++ b/inc/WireCellGenKokkos/KokkosEnv.h
@@ -1,0 +1,23 @@
+#ifndef WIRECELL_GENKOKKOS_KOKKOSENV
+#define WIRECELL_GENKOKKOS_KOKKOSENV
+
+#include "WireCellIface/ITerminal.h"
+#include "WireCellUtil/Logging.h"
+
+namespace WireCell {
+    namespace GenKokkos {
+        class KokkosEnv : public WireCell::ITerminal {
+           private:
+            static bool kokkos_initialized;
+            Log::logptr_t log;
+
+           public:
+            KokkosEnv();
+            virtual ~KokkosEnv();
+            virtual void finalize();
+        };
+
+    }  // namespace GenKokkos
+}  // namespace WireCell
+
+#endif

--- a/inc/WireCellGenKokkos/KokkosTestFrameFilter.h
+++ b/inc/WireCellGenKokkos/KokkosTestFrameFilter.h
@@ -7,7 +7,6 @@
 
 #include "WireCellIface/IConfigurable.h"
 #include "WireCellIface/IFrameFilter.h"
-#include "WireCellUtil/Logging.h"
 
 namespace WireCell {
     namespace GenKokkos {
@@ -31,9 +30,6 @@ namespace WireCell {
 
            private:
             Configuration m_cfg;  /// copy of configuration
-
-            /// SPD logger
-            Log::logptr_t log;
         };
     }  // namespace GenKokkos
 }  // namespace WireCell

--- a/inc/WireCellGenKokkos/KokkosTestFrameFilter.h
+++ b/inc/WireCellGenKokkos/KokkosTestFrameFilter.h
@@ -1,0 +1,41 @@
+/**
+ * To test if Kokkos works.
+ */
+
+#ifndef WIRECELL_GENKOKKOS_KOKKOSTESTFRAMEFILTER
+#define WIRECELL_GENKOKKOS_KOKKOSTESTFRAMEFILTER
+
+#include "WireCellIface/IConfigurable.h"
+#include "WireCellIface/IFrameFilter.h"
+#include "WireCellUtil/Logging.h"
+
+namespace WireCell {
+    namespace GenKokkos {
+
+        class KokkosTestFrameFilter : public IFrameFilter, public IConfigurable {
+           public:
+            KokkosTestFrameFilter();
+            virtual ~KokkosTestFrameFilter();
+
+            /// working operation - interface from IFrameFilter
+            /// executed when called by pgrapher
+            virtual bool operator()(const IFrame::pointer &inframe, IFrame::pointer &outframe);
+
+            /// interfaces from IConfigurable
+
+            /// exeexecuted once at node creation
+            virtual WireCell::Configuration default_configuration() const;
+
+            /// executed once after node creation
+            virtual void configure(const WireCell::Configuration &config);
+
+           private:
+            Configuration m_cfg;  /// copy of configuration
+
+            /// SPD logger
+            Log::logptr_t log;
+        };
+    }  // namespace GenKokkos
+}  // namespace WireCell
+
+#endif

--- a/src/KokkosEnv.cxx
+++ b/src/KokkosEnv.cxx
@@ -1,0 +1,5 @@
+#include "WireCellGenKokkos/KokkosEnv.h"
+
+#include "WireCellUtil/NamedFactory.h"
+
+WIRECELL_FACTORY(KokkosEnv, WireCell::GenKokkos::KokkosEnv, WireCell::ITerminal)

--- a/src/KokkosEnv.kokkos
+++ b/src/KokkosEnv.kokkos
@@ -1,0 +1,50 @@
+#include <Kokkos_Core.hpp>
+
+#include "WireCellGenKokkos/KokkosEnv.h"
+
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/Exceptions.h"
+
+#include <iostream>
+
+WIRECELL_FACTORY(KokkosEnv, WireCell::GenKokkos::KokkosEnv, WireCell::ITerminal)
+
+using namespace WireCell;
+using namespace std;
+
+bool GenKokkos::KokkosEnv::kokkos_initialized = false;
+
+GenKokkos::KokkosEnv::KokkosEnv()
+  : log(Log::logger("env"))
+{
+    log->debug("Kokkos::initializing");
+    if (!kokkos_initialized) {
+        try {
+            Kokkos::initialize();
+            kokkos_initialized = true;
+        }
+        catch (Exception& e) {
+            cerr << errstr(e) << endl;
+            THROW(RuntimeError() << errmsg{"Kokkos::initialize() FAILED!"});
+        }
+    }
+    log->debug("Kokkos::initialized");
+}
+
+GenKokkos::KokkosEnv::~KokkosEnv() {}
+
+void GenKokkos::KokkosEnv::finalize()
+{
+    log->debug("Kokkos::finalizing");
+    if (kokkos_initialized) {
+        try {
+            Kokkos::finalize();
+            kokkos_initialized = false;
+        }
+        catch (Exception& e) {
+            cerr << errstr(e) << endl;
+            THROW(RuntimeError() << errmsg{"Kokkos::finalize() FAILED!"});
+        }
+    }
+    log->debug("Kokkos::finalized");
+}

--- a/src/KokkosEnv.kokkos
+++ b/src/KokkosEnv.kokkos
@@ -2,12 +2,9 @@
 
 #include "WireCellGenKokkos/KokkosEnv.h"
 
-#include "WireCellUtil/NamedFactory.h"
 #include "WireCellUtil/Exceptions.h"
 
 #include <iostream>
-
-WIRECELL_FACTORY(KokkosEnv, WireCell::GenKokkos::KokkosEnv, WireCell::ITerminal)
 
 using namespace WireCell;
 using namespace std;
@@ -15,9 +12,8 @@ using namespace std;
 bool GenKokkos::KokkosEnv::kokkos_initialized = false;
 
 GenKokkos::KokkosEnv::KokkosEnv()
-  : log(Log::logger("env"))
 {
-    log->debug("Kokkos::initializing");
+    std::cout << "Kokkos::initializing" << std::endl;
     if (!kokkos_initialized) {
         try {
             Kokkos::initialize();
@@ -28,14 +24,14 @@ GenKokkos::KokkosEnv::KokkosEnv()
             THROW(RuntimeError() << errmsg{"Kokkos::initialize() FAILED!"});
         }
     }
-    log->debug("Kokkos::initialized");
+    std::cout << "Kokkos::initialized" << std::endl;
 }
 
 GenKokkos::KokkosEnv::~KokkosEnv() {}
 
 void GenKokkos::KokkosEnv::finalize()
 {
-    log->debug("Kokkos::finalizing");
+    std::cout << "Kokkos::finalizing" << std::endl;
     if (kokkos_initialized) {
         try {
             Kokkos::finalize();
@@ -46,5 +42,5 @@ void GenKokkos::KokkosEnv::finalize()
             THROW(RuntimeError() << errmsg{"Kokkos::finalize() FAILED!"});
         }
     }
-    log->debug("Kokkos::finalized");
+    std::cout << "Kokkos::finalized" << std::endl;
 }

--- a/src/KokkosTestFrameFilter.cxx
+++ b/src/KokkosTestFrameFilter.cxx
@@ -1,0 +1,6 @@
+#include "WireCellGenKokkos/KokkosTestFrameFilter.h"
+
+#include "WireCellUtil/NamedFactory.h"
+
+WIRECELL_FACTORY(KokkosTestFrameFilter, WireCell::GenKokkos::KokkosTestFrameFilter, WireCell::IFrameFilter,
+                 WireCell::IConfigurable)

--- a/src/KokkosTestFrameFilter.kokkos
+++ b/src/KokkosTestFrameFilter.kokkos
@@ -1,0 +1,126 @@
+#include <Kokkos_Core.hpp>
+
+#include "WireCellGenKokkos/KokkosTestFrameFilter.h"
+
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/Exceptions.h"
+
+WIRECELL_FACTORY(KokkosTestFrameFilter, WireCell::GenKokkos::KokkosTestFrameFilter, WireCell::IFrameFilter,
+                 WireCell::IConfigurable)
+
+using namespace WireCell;
+using namespace std;
+
+GenKokkos::KokkosTestFrameFilter::KokkosTestFrameFilter()
+  : log(Log::logger("kokkos"))
+{
+}
+
+GenKokkos::KokkosTestFrameFilter::~KokkosTestFrameFilter() {}
+
+void GenKokkos::KokkosTestFrameFilter::configure(const WireCell::Configuration &cfg) { m_cfg = cfg; }
+
+WireCell::Configuration GenKokkos::KokkosTestFrameFilter::default_configuration() const
+{
+    Configuration cfg;
+    return cfg;
+}
+
+bool GenKokkos::KokkosTestFrameFilter::operator()(const IFrame::pointer &inframe, IFrame::pointer &outframe)
+{
+    outframe = inframe;
+
+    log->debug("========== KokkosTestFrameFilter: start ==========");
+
+    try {
+        int N = 4096;
+        int M = 1024;
+        int nrepeat = 100;
+
+        // Allocate y, x vectors and Matrix A on device.
+        typedef Kokkos::View<double *> ViewVectorType;
+        typedef Kokkos::View<double **> ViewMatrixType;
+        ViewVectorType y("y", N);
+        ViewVectorType x("x", M);
+        ViewMatrixType A("A", N, M);
+
+        // Create host mirrors of device views.
+        ViewVectorType::HostMirror h_y = Kokkos::create_mirror_view(y);
+        ViewVectorType::HostMirror h_x = Kokkos::create_mirror_view(x);
+        ViewMatrixType::HostMirror h_A = Kokkos::create_mirror_view(A);
+
+        // Initialize y vector on host.
+        for (int i = 0; i < N; ++i) {
+            h_y(i) = 1;
+        }
+
+        // Initialize x vector on host.
+        for (int i = 0; i < M; ++i) {
+            h_x(i) = 1;
+        }
+
+        // Initialize A matrix on host.
+        for (int j = 0; j < N; ++j) {
+            for (int i = 0; i < M; ++i) {
+                h_A(j, i) = 1;
+            }
+        }
+
+        // Deep copy host views to device views.
+        Kokkos::deep_copy(y, h_y);
+        Kokkos::deep_copy(x, h_x);
+        Kokkos::deep_copy(A, h_A);
+
+        // Timer products.
+        Kokkos::Timer timer;
+
+        for (int repeat = 0; repeat < nrepeat; repeat++) {
+            // Application: <y,Ax> = y^T*A*x
+            double result = 0;
+
+            Kokkos::parallel_reduce("yAx", N,
+                                    KOKKOS_LAMBDA(int j, double &update) {
+                                        double temp2 = 0;
+
+                                        for (int i = 0; i < M; ++i) {
+                                            temp2 += A(j, i) * x(i);
+                                        }
+
+                                        update += y(j) * temp2;
+                                    },
+                                    result);
+
+            // Output result.
+            if (repeat == (nrepeat - 1)) {
+                printf("  Computed result for %d x %d is %lf\n", N, M, result);
+            }
+
+            const double solution = (double) N * (double) M;
+
+            if (result != solution) {
+                printf("  Error: result( %lf ) != solution( %lf )\n", result, solution);
+            }
+        }
+
+        // Calculate time.
+        double time = timer.seconds();
+
+        // Calculate bandwidth.
+        // Each matrix A row (each of length M) is read once.
+        // The x vector (of length M) is read N times.
+        // The y vector (of length N) is read once.
+        // double Gbytes = 1.0e-9 * double( sizeof(double) * ( 2 * M * N + N ) );
+        double Gbytes = 1.0e-9 * double(sizeof(double) * (M + M * N + N));
+
+        // Print results (problem size, time and bandwidth in GB/s).
+        printf("  N( %d ) M( %d ) nrepeat ( %d ) problem( %g MB ) time( %g s ) bandwidth( %g GB/s )\n", N, M, nrepeat,
+               Gbytes * 1000, time, Gbytes * nrepeat / time);
+    }
+    catch (Exception &e) {
+        cerr << errstr(e) << endl;
+    }
+
+    log->debug("========== KokkosTestFrameFilter: end ==========");
+
+    return true;
+}

--- a/src/KokkosTestFrameFilter.kokkos
+++ b/src/KokkosTestFrameFilter.kokkos
@@ -2,17 +2,12 @@
 
 #include "WireCellGenKokkos/KokkosTestFrameFilter.h"
 
-#include "WireCellUtil/NamedFactory.h"
 #include "WireCellUtil/Exceptions.h"
-
-WIRECELL_FACTORY(KokkosTestFrameFilter, WireCell::GenKokkos::KokkosTestFrameFilter, WireCell::IFrameFilter,
-                 WireCell::IConfigurable)
 
 using namespace WireCell;
 using namespace std;
 
 GenKokkos::KokkosTestFrameFilter::KokkosTestFrameFilter()
-  : log(Log::logger("kokkos"))
 {
 }
 
@@ -30,7 +25,7 @@ bool GenKokkos::KokkosTestFrameFilter::operator()(const IFrame::pointer &inframe
 {
     outframe = inframe;
 
-    log->debug("========== KokkosTestFrameFilter: start ==========");
+    std::cout << "========== KokkosTestFrameFilter: start ==========" << std::endl;
 
     try {
         int N = 4096;
@@ -120,7 +115,7 @@ bool GenKokkos::KokkosTestFrameFilter::operator()(const IFrame::pointer &inframe
         cerr << errstr(e) << endl;
     }
 
-    log->debug("========== KokkosTestFrameFilter: end ==========");
+    std::cout << "========== KokkosTestFrameFilter: end ==========" << std::endl;
 
     return true;
 }

--- a/src/KokkosTestFrameFilter.kokkos
+++ b/src/KokkosTestFrameFilter.kokkos
@@ -24,6 +24,9 @@ WireCell::Configuration GenKokkos::KokkosTestFrameFilter::default_configuration(
 bool GenKokkos::KokkosTestFrameFilter::operator()(const IFrame::pointer &inframe, IFrame::pointer &outframe)
 {
     outframe = inframe;
+    if(!inframe) {
+        return true;
+    }
 
     std::cout << "========== KokkosTestFrameFilter: start ==========" << std::endl;
 


### PR DESCRIPTION
Initial implementation of `KokkosEnv` that calls `Kokkos::init` and `Kokkos::fin` to provide a Kokkos environment.
Takes no arguments right now. Could take external arguments in future version.

Example setup:
```
local app = {
  type: engine,
  data: {
    edges: g.edges(graph),
  },
};

local env = {
    type: "KokkosEnv",
};


// Finally, the configuration sequence which is emitted.
[env] + g.uses(graph) + [app]
```

`KokkosTestFrameFilter` passes on frame pointer without modification + some Kokkos tests for testing (matrix multiplication for now).

Example output with KokkosEnv:
Kokkos-OMP:
![image](https://user-images.githubusercontent.com/10383186/104641181-70e3b400-5677-11eb-8075-c5ef35c5aab7.png)

Kokkos_CUDA:
![image](https://user-images.githubusercontent.com/10383186/104641200-7640fe80-5677-11eb-9d8e-5a80a0de36be.png)



