### PR TITLE
Dirty fix for cuda back end to work with cmake

### DIFF
--- a/.cmake-kokkos/CMakeLists.txt
+++ b/.cmake-kokkos/CMakeLists.txt
@@ -4,7 +4,7 @@ project(wire-cell-gen-kokkos CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS Off)
 
-file(GLOB all_files ${PROJECT_SOURCE_DIR}/../src/*.kokkos)
+file(GLOB all_files ${PROJECT_SOURCE_DIR}/src/*.cxx)
 
 include_directories(SYSTEM $ENV{BOOST_INC})
 

--- a/build-cmake
+++ b/build-cmake
@@ -13,6 +13,17 @@ build_dir_cxx=$top_dir/build/cxx
 build_dir_kokkos=$top_dir/build/kokkos
 mkdir -p $build_dir_cxx $build_dir_kokkos
 
+src_rn_dir=$cmake_dir_kokkos/src
+mkdir -p $src_rn_dir
+
+cd $top_dir/src
+cp *.cxx ${src_rn_dir}
+for file in *.kokkos
+do
+  cp  $file ${src_rn_dir}/$(basename "$file" .kokkos).kokkos.cxx
+done
+
+
 build_cmds="$@"
 
 echo
@@ -20,10 +31,10 @@ echo "======================="
 echo "Building CXX components"
 echo "======================="
 echo
-cd $build_dir_cxx
-[ ! -f Makefile ] && \
-    (cmake $cmake_dir_cxx -DCMAKE_CXX_EXTENSIONS=Off || exit 2)
-make $build_cmds || exit 3
+#cd $build_dir_cxx
+#[ ! -f Makefile ] && \
+#    (cmake $cmake_dir_cxx -DCMAKE_CXX_EXTENSIONS=Off || exit 2)
+#make $build_cmds || exit 3
 
 echo
 echo "=========================="

--- a/src/BinnedDiffusion_transform.cxx
+++ b/src/BinnedDiffusion_transform.cxx
@@ -76,7 +76,7 @@ struct generate_random {
             double u1 = (double) rand_gen1.urand64(range_min, range_max1) / range_max1; 
             double u2 = (double) rand_gen2.urand64(range_min, range_max2) / range_max2; 
             normals(i * samples + k)     = sqrt(-2*log(u1)) * cos(2*PI*u2);
-            normals(i * samples + k + 1) = sqrt(-2*log(u1)) * sin(2*PI*u2);
+            //normals(i * samples + k + 1) = sqrt(-2*log(u1)) * sin(2*PI*u2);
         }
 
         rand_pool1.free_state(rand_gen1);


### PR DESCRIPTION
After "enable_kokkos_cuda"
set SPDLOG_INC  to newer version of spdlog_src/include e.g v1.8.0
./build-cmake