### PR TITLE
Use TeamPolicy and TeamThreadRange for patch calculation

### DIFF
--- a/inc/WireCellGenKokkos/BinnedDiffusion_transform.h
+++ b/inc/WireCellGenKokkos/BinnedDiffusion_transform.h
@@ -130,7 +130,7 @@ namespace WireCell {
 	    std::map<int, GenKokkos::ImpactData::mutable_pointer> m_impacts;
             //std::vector<std::shared_ptr<GaussianDiffusion> > m_diffs;
 	    //std::set<std::shared_ptr<GaussianDiffusion>, GausDiffTimeCompare> m_diffs;
-	    std::set<std::shared_ptr<GaussianDiffusion> > m_diffs;
+	    std::vector<std::shared_ptr<GaussianDiffusion> > m_diffs;
 
             int m_outside_pitch;
             int m_outside_time;

--- a/inc/WireCellGenKokkos/BinnedDiffusion_transform.h
+++ b/inc/WireCellGenKokkos/BinnedDiffusion_transform.h
@@ -113,7 +113,7 @@ namespace WireCell {
 
 	    double get_nsigma() const {return m_nsigma;};
 
-	    void set_sampling_bat( const unsigned long npatch) ;
+	    void set_sampling_bat( const unsigned long npatch, int patch_size) ;
 	    
 	private:
 	    

--- a/inc/WireCellGenKokkos/GaussianDiffusion.h
+++ b/inc/WireCellGenKokkos/GaussianDiffusion.h
@@ -127,6 +127,7 @@ namespace WireCell {
                               unsigned int weightstrat = 1/*see BinnedDiffusion ImpactDataCalculationStrategy*/);
             void set_sampling_pre(
                               const int counter,
+			      int & patch_size ,
                               double* pvecs,
                               double* tvecs,
                               double* charges,

--- a/src/BinnedDiffusion_transform.cxx
+++ b/src/BinnedDiffusion_transform.cxx
@@ -536,16 +536,16 @@ void GenKokkos::BinnedDiffusion_transform::set_sampling_bat(unsigned long npatch
   Kokkos::View<unsigned long*, Kokkos::HostSpace> patch_idx_v_h(&m_patch_idx_h[0],npatches+1) ;
   Kokkos::View<float* , Kokkos::HostSpace> patches_v_h(&m_patch_h[0], m_patch_idx_h[npatches] ) ;
 
-  Kokkos::View<double*> sum_p_v("PatchSum", npatches) ;
+  Kokkos::View<double*> sum_p_v(Kokkos::ViewAllocateWithoutInitializing("PatchSum"), npatches) ;
 
   //Device Views
-  Kokkos::View<unsigned long * > p_idx("P_idx:" , npatches+1) ;
-  Kokkos::View<unsigned long * > t_idx("T_idx:" , npatches+1) ;
-  Kokkos::View<unsigned long * > patch_idx("Pat_idx:" , npatches+1) ;
-  Kokkos::View<float * > patch_d("Patches:" , m_patch_idx_h[npatches]) ;
-  Kokkos::View<double * > pvecs_d("Pvecs:" , m_p_idx_h[npatches]) ;
-  Kokkos::View<double * > tvecs_d("Tvecs:" , m_t_idx_h[npatches]) ;
-  Kokkos::View<double * > charges_d("Charges:" , npatches) ;
+  Kokkos::View<unsigned long * > p_idx(Kokkos::ViewAllocateWithoutInitializing("P_idx") , npatches+1) ;
+  Kokkos::View<unsigned long * > t_idx(Kokkos::ViewAllocateWithoutInitializing("T_idx") , npatches+1) ;
+  Kokkos::View<unsigned long * > patch_idx(Kokkos::ViewAllocateWithoutInitializing("Pat_idx") , npatches+1) ;
+  Kokkos::View<float * > patch_d(Kokkos::ViewAllocateWithoutInitializing("Patches") , m_patch_idx_h[npatches]) ;
+  Kokkos::View<double * > pvecs_d(Kokkos::ViewAllocateWithoutInitializing("Pvecs") , m_p_idx_h[npatches]) ;
+  Kokkos::View<double * > tvecs_d(Kokkos::ViewAllocateWithoutInitializing("Tvecs") , m_t_idx_h[npatches]) ;
+  Kokkos::View<double * > charges_d(Kokkos::ViewAllocateWithoutInitializing("Charges") , npatches) ;
 
 
   auto normals = Kokkos::subview(m_normals,std::make_pair((size_t)0, (size_t)m_patch_idx_h[npatches] ) ) ;

--- a/src/BinnedDiffusion_transform.cxx
+++ b/src/BinnedDiffusion_transform.cxx
@@ -424,6 +424,8 @@ void GenKokkos::BinnedDiffusion_transform::get_charge_vec(std::vector<std::vecto
   m_t_idx_h[0]=0 ;
   m_p_idx_h[0]=0 ;
   m_patch_idx_h[0]=0 ;
+  int max_patch_size = 0 ;
+  int patch_size =0 ;
   for (auto diff : m_diffs){
     if(diff->depo()->charge()==0) continue;
     wstart2 = omp_get_wtime();
@@ -432,17 +434,18 @@ void GenKokkos::BinnedDiffusion_transform::get_charge_vec(std::vector<std::vecto
     #else
     //diff->set_sampling(m_pvec, m_tvec, m_patch, m_normals, m_tbins, ib, m_nsigma, m_fluctuate, m_calcstrat);
     //diff->set_sampling(m_patch, m_normals, m_ptvecs, (double*)m_ptvecs_h, m_tbins, ib, m_nsigma, m_fluctuate, m_calcstrat);
-    diff->set_sampling_pre(counter,m_pvecs_h,m_tvecs_h,m_charges_h,m_p_idx_h,m_t_idx_h,m_patch_idx_h, m_tbins, ib, m_nsigma, m_fluctuate, m_calcstrat);
+    diff->set_sampling_pre(counter,patch_size,m_pvecs_h,m_tvecs_h,m_charges_h,m_p_idx_h,m_t_idx_h,m_patch_idx_h, m_tbins, ib, m_nsigma, m_fluctuate, m_calcstrat);
     //diff->set_sampling(m_tbins, ib, m_nsigma, m_fluctuate, m_calcstrat);
     #endif
     wend2 = omp_get_wtime();
     g_get_charge_vec_time_part4 += wend2 - wstart2;
     counter ++;
+    max_patch_size = max_patch_size > patch_size ? max_patch_size : patch_size ;
   }
   wend = omp_get_wtime();
   cout << "get_charge_vec() : get_charge_vec() set_sampling_pre() time " << wend- wstart<< endl;
 
-  set_sampling_bat( counter) ;
+  set_sampling_bat( counter, max_patch_size) ;
   wstart = omp_get_wtime();
   cout << "get_charge_vec() : get_charge_vec() set_sampling_bat() time " << wstart-wend<< endl;
 
@@ -526,7 +529,7 @@ void GenKokkos::BinnedDiffusion_transform::get_charge_vec(std::vector<std::vecto
 #endif
 }
 
-void GenKokkos::BinnedDiffusion_transform::set_sampling_bat(unsigned long npatches) {
+void GenKokkos::BinnedDiffusion_transform::set_sampling_bat(unsigned long npatches, int max_patch_size) {
 
   //create hostview from pointers
   Kokkos::View<double*, Kokkos::HostSpace> pvecs_v_h(m_pvecs_h,m_p_idx_h[npatches]);
@@ -562,9 +565,64 @@ void GenKokkos::BinnedDiffusion_transform::set_sampling_bat(unsigned long npatch
   if( m_fluctuate) fl = true    ;
   //kernels
 
-  Kokkos::TeamPolicy<> policy = Kokkos::TeamPolicy<>(npatches,P_BLOCK_SIZE) ;
-  Kokkos::parallel_for( policy, 
-    KOKKOS_LAMBDA( const Kokkos::TeamPolicy<>::member_type & team ){
+  bool is_host= std::is_same<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>::value ;
+  std::cout<<"Is_host: " << is_host <<std::endl ;
+
+  if(is_host) {   //if not use GPU 
+    Kokkos::parallel_for("Patch", npatches,
+       KOKKOS_LAMBDA( int p ){
+       int np=p_idx(p+1)-p_idx(p) ;
+       int nt=t_idx(p+1)-t_idx(p) ;
+       int patch_size=np*nt ;
+       double sum_p=0.0 ;
+       for (int ii=0 ; ii<patch_size ; ii++) {
+            double value=pvecs_d(p_idx(p)+ii%np)*tvecs_d(t_idx(p)+ii/np);
+            patch_d(patch_idx(p)+ii)=(float)value ;
+            sum_p +=value ;
+       }
+       sum_p_v(p) =sum_p ;
+
+        } ) ;
+
+    if(! m_fluctuate){
+        Kokkos::parallel_for("Norm1", npatches , KOKKOS_LAMBDA(int p) {
+              float factor= abs(charges_d(p))/sum_p_v(p) ;
+              for (unsigned long  ii=patch_idx(p) ; ii< patch_idx(p+1) ; ii++) {
+                  patch_d(ii) *= factor ;
+              }
+        }) ;
+    } else {
+        Kokkos::parallel_for("Set_Sample", npatches , KOKKOS_LAMBDA(int i) {
+               double charge=abs(charges_d(i)) ;
+               int n=(int) charge;
+               double sum_p =0 ;
+
+               float factor= abs(charges_d(i))/sum_p_v(i) ;
+               for (unsigned long  ii=patch_idx(i) ; ii< patch_idx(i+1) ; ii++) {
+                   patch_d(ii) *= factor ;
+                   double p = patch_d(ii)/charge ;
+                   double q = 1-p ;
+                   double mu = n*p ;
+                   double sigma = sqrt(p*q*n) ;
+                   double value = normals(ii)*sigma + mu ;
+                   patch_d(ii) = value ;
+                  sum_p += value ;
+               }
+
+              for (unsigned long  ii=patch_idx(i) ; ii< patch_idx(i+1) ; ii++) {
+                   patch_d(ii) *= (charge/sum_p) ;
+              }
+
+        } ) ;
+    }
+  } else {  // use GPU/cuda
+    int blocksize= 1 ;
+    while (blocksize <max_patch_size) blocksize*=2 ;
+
+    std::cout<<"Max Patch size : " << max_patch_size << " Block size: "<< blocksize <<std::endl ;
+    Kokkos::TeamPolicy<> policy = Kokkos::TeamPolicy<>(npatches,blocksize) ;
+    Kokkos::parallel_for( policy, 
+      KOKKOS_LAMBDA( const Kokkos::TeamPolicy<>::member_type & team ){
        int ip=team.league_rank() ;
        int ii=team.team_rank() ;
        
@@ -589,7 +647,7 @@ void GenKokkos::BinnedDiffusion_transform::set_sampling_bat(unsigned long npatch
        
 	   int n=(int) charge_abs;
 	   unsigned long p0 =patch_idx(ip) ;
-	   unsigned long p1 =patch_idx(ip+1) ;
+	   //unsigned long p1 =patch_idx(ip+1) ;
 
 	   if( ii < patch_size  ) { 
                p =  value/charge_abs ;
@@ -607,8 +665,8 @@ void GenKokkos::BinnedDiffusion_transform::set_sampling_bat(unsigned long npatch
 
        }
 
-
     } ) ;
+  }
  
   Kokkos::deep_copy(patches_v_h, patch_d ) ;
 

--- a/src/BinnedDiffusion_transform.cxx
+++ b/src/BinnedDiffusion_transform.cxx
@@ -124,8 +124,8 @@ GenKokkos::BinnedDiffusion_transform::BinnedDiffusion_transform(const Pimpos& pi
     , m_outside_pitch(0)
     , m_outside_time(0)
 {
-    Kokkos::realloc(m_patch, MAX_PATCH_SIZE*MAX_PATCHES);
-    Kokkos::realloc(m_ptvecs, MAX_NPSS_DEVICE+MAX_NTSS_DEVICE);
+    //Kokkos::realloc(m_patch, MAX_PATCH_SIZE*MAX_PATCHES);
+    //Kokkos::realloc(m_ptvecs, MAX_NPSS_DEVICE+MAX_NTSS_DEVICE);
     m_ptvecs_h = (void*)malloc((MAX_NPSS_DEVICE+MAX_NTSS_DEVICE)*sizeof(double)) ;
     m_pvecs_h = (double*)malloc((MAX_NPSS_DEVICE*MAX_PATCHES)*sizeof(double)) ;
     m_tvecs_h = (double*)malloc((MAX_NTSS_DEVICE*MAX_PATCHES)*sizeof(double)) ;

--- a/src/GaussianDiffusion.cxx
+++ b/src/GaussianDiffusion.cxx
@@ -529,6 +529,7 @@ void GenKokkos::GaussianDiffusion::set_sampling(
 
 void GenKokkos::GaussianDiffusion::set_sampling_pre(
 					        const int diff_idx ,
+						int & patch_size ,
                                                 double* p_vecs,
                                                 double* t_vecs,
                                                 double* charges, 
@@ -584,6 +585,7 @@ void GenKokkos::GaussianDiffusion::set_sampling_pre(
         return;
     }
 
+    patch_size = ntss*npss ;
 
     // make charge weights for later interpolation.
     /// fixme: for hanyu.


### PR DESCRIPTION
This version  kernel works for both cuda and omp backend.  And  kernel  for cuda beackend  is about 0.5ms for the test dataset we use. 