### PR TITLE
Catch up with WCT 0.20.0 (IDFT)

### DIFF
--- a/.cmake-kokkos/CMakeLists.txt
+++ b/.cmake-kokkos/CMakeLists.txt
@@ -47,6 +47,6 @@ set_target_properties(WireCellGenKokkos
 	PROPERTIES COMPILE_OPTIONS "-DEIGEN_NO_CUDA;-DEIGEN_DONT_VECTORIZE")
 
 target_link_directories(WireCellGenKokkos PRIVATE  $ENV{JSONCPP_LIB} $ENV{WIRECELL_LIB})
-target_link_libraries(WireCellGenKokkos PRIVATE  jsoncpp WireCellIface WireCellUtil Boost::headers Kokkos::kokkos ${CUDA_CUFFT_LIBRARIES})
+target_link_libraries(WireCellGenKokkos PRIVATE  jsoncpp WireCellIface WireCellAux WireCellUtil Boost::headers Kokkos::kokkos ${CUDA_CUFFT_LIBRARIES})
 
 add_subdirectory(test)

--- a/example/wct-sim.jsonnet
+++ b/example/wct-sim.jsonnet
@@ -112,7 +112,7 @@ local depo_source  = g.pnode({
 }, nin=0, nout=1);
 
 local graph = g.pipeline([depo_source, setdrifter, bi_manifold, retagger, sio_sinks]);
-local plugins = [ "WireCellSio", "WireCellGen", "WireCellSigProc","WireCellApps", "WireCellPgraph", "WireCellTbb", "WireCellRoot", "WireCellGenKokkos"];
+local plugins = [ "WireCellSio", "WireCellGen", "WireCellSigProc","WireCellApps", "WireCellPgraph", "WireCellTbb", "WireCellGenKokkos"];
 
 // Pgrapher or TbbFlow
 local engine = "Pgrapher";

--- a/example/wct-sim.jsonnet
+++ b/example/wct-sim.jsonnet
@@ -112,7 +112,7 @@ local depo_source  = g.pnode({
 }, nin=0, nout=1);
 
 local graph = g.pipeline([depo_source, setdrifter, bi_manifold, retagger, sio_sinks]);
-local plugins = [ "WireCellSio", "WireCellGen", "WireCellSigProc","WireCellApps", "WireCellPgraph", "WireCellTbb", "WireCellRoot"];
+local plugins = [ "WireCellSio", "WireCellGen", "WireCellSigProc","WireCellApps", "WireCellPgraph", "WireCellTbb", "WireCellRoot", "WireCellGenKokkos"];
 
 // Pgrapher or TbbFlow
 local engine = "Pgrapher";
@@ -131,6 +131,9 @@ local cmdline = {
     }
 };
 
+local env = {
+    type: "KokkosEnv",
+};
 
 // Finally, the configuration sequence which is emitted.
-[cmdline] + g.uses(graph) + [app]
+[env] + [cmdline] + g.uses(graph) + [app]

--- a/inc/WireCellGenKokkos/DepoTransform.h
+++ b/inc/WireCellGenKokkos/DepoTransform.h
@@ -7,6 +7,7 @@
 #include "WireCellIface/IDepoFramer.h"
 #include "WireCellIface/IConfigurable.h"
 #include "WireCellIface/IRandom.h"
+#include "WireCellIface/IDFT.h"
 #include "WireCellIface/IPlaneImpactResponse.h"
 #include "WireCellIface/IAnodePlane.h"
 #include "WireCellIface/WirePlaneId.h"
@@ -34,6 +35,7 @@ namespace WireCell {
            private:
             IAnodePlane::pointer m_anode;
             IRandom::pointer m_rng;
+            IDFT::pointer m_dft;
             std::vector<IPlaneImpactResponse::pointer> m_pirs;
 
             double m_start_time;

--- a/inc/WireCellGenKokkos/ImpactData.h
+++ b/inc/WireCellGenKokkos/ImpactData.h
@@ -4,13 +4,16 @@
  */
 
 #include "WireCellUtil/Waveform.h"
+
+#include "WireCellIface/IDFT.h"
+
 #include "WireCellGenKokkos/GaussianDiffusion.h"
 
 #include <memory>
 #include <vector>
 
-#ifndef WIRECELLGEN_IMPACTDATA
-#define WIRECELLGEN_IMPACTDATA
+#ifndef WIRECELL_GENKOKKOS_IMPACTDATA
+#define WIRECELL_GENKOKKOS_IMPACTDATA
 
 namespace WireCell {
     namespace GenKokkos {
@@ -56,7 +59,7 @@ namespace WireCell {
              * linear or constant (all = 0.5),
              * and honoring the Gaussian distribution (diffusion).
              */
-	    void calculate(int nticks) const;
+	    void calculate(const IDFT::pointer& dft, int nticks) const;
 
 
 

--- a/inc/WireCellGenKokkos/ImpactTransform.h
+++ b/inc/WireCellGenKokkos/ImpactTransform.h
@@ -1,8 +1,9 @@
 #ifndef WIRECELL_GENKOKKOS_IMPACTTRANSFORM
 #define WIRECELL_GENKOKKOS_IMPACTTRANSFORM
 
-#include "WireCellIface/IPlaneImpactResponse.h"
 #include "WireCellGenKokkos/BinnedDiffusion_transform.h"
+#include "WireCellIface/IPlaneImpactResponse.h"
+#include "WireCellIface/IDFT.h"
 #include "WireCellUtil/Array.h"
 #include "WireCellUtil/Logging.h"
 
@@ -16,6 +17,7 @@ namespace WireCell {
          */
         class ImpactTransform {
             IPlaneImpactResponse::pointer m_pir;
+            IDFT::pointer m_dft;
             BinnedDiffusion_transform& m_bd;
 
             int m_num_group;     // how many 2D convolution is needed
@@ -35,7 +37,7 @@ namespace WireCell {
             Log::logptr_t log;
 
            public:
-            ImpactTransform(IPlaneImpactResponse::pointer pir, BinnedDiffusion_transform& bd);
+            ImpactTransform(IPlaneImpactResponse::pointer pir, const IDFT::pointer& dft, BinnedDiffusion_transform& bd);
             virtual ~ImpactTransform();
 
             bool transform_vector();

--- a/inc/WireCellGenKokkos/KokkosArray_fftw.h
+++ b/inc/WireCellGenKokkos/KokkosArray_fftw.h
@@ -5,7 +5,7 @@
 #ifndef WIRECELL_KOKKOSARRAY_FFTW
 #define WIRECELL_KOKKOSARRAY_FFTW
 
-#include <WireCellUtil/Array.h> // tmp solution
+#include <unsupported/Eigen/FFT>
 #include <iostream> //debug
 
 namespace WireCell {
@@ -19,6 +19,10 @@ namespace WireCell {
          * FIXME: float should be Scalar
          */
         thread_local static Eigen::FFT<float> gEigenFFT;
+        thread_local static Eigen::FFT<float> gEigenFFT_dft_1d;      // c2c fwd and inv
+        thread_local static Eigen::FFT<float> gEigenFFT_dft_r2c_1d;  // r2c fwd
+        thread_local static Eigen::FFT<float> gEigenFFT_dft_c2r_1d;  // c2r inv
+
         inline array_xc dft(const array_xf& in)
         {
             Eigen::Map<Eigen::VectorXf> in_eigen((float*) in.data(), in.extent(0));
@@ -39,7 +43,31 @@ namespace WireCell {
         {
             std::cout << "WIRECELL_KOKKOSARRAY_FFTW" << std::endl;
             Eigen::Map<Eigen::ArrayXXf> in_eigen((float*) in.data(), in.extent(0), in.extent(1));
-            auto out_eigen = WireCell::Array::dft_rc(in_eigen, dim);
+            
+            // auto out_eigen = WireCell::Array::dft_rc(in_eigen, dim);
+
+            const int nrows = in_eigen.rows();
+            const int ncols = in_eigen.cols();
+
+            Eigen::MatrixXcf out_eigen(nrows, ncols);
+
+            if (dim == 0) {
+                for (int irow = 0; irow < nrows; ++irow) {
+                    Eigen::VectorXcf fspec(ncols);
+                    Eigen::VectorXf tmp = in_eigen.row(irow);
+                    gEigenFFT_dft_r2c_1d.fwd(fspec, tmp);  // r2c
+                    out_eigen.row(irow) = fspec;
+                }
+            }
+            else if (dim == 1) {
+                for (int icol = 0; icol < ncols; ++icol) {
+                    Eigen::VectorXcf fspec(nrows);
+                    Eigen::VectorXf tmp = in_eigen.col(icol);
+                    gEigenFFT_dft_r2c_1d.fwd(fspec, tmp);  // r2c
+                    out_eigen.col(icol) = fspec;
+                }
+            }
+
             auto out = gen_2d_view<array_xxc>(out_eigen.rows(), out_eigen.cols(), 0);
             memcpy( (void*)out.data(), (void*)out_eigen.data(), out_eigen.rows()*out_eigen.cols()*sizeof(Scalar) * 2);
 
@@ -48,7 +76,31 @@ namespace WireCell {
         inline array_xxc dft_cc(const array_xxc& in, int dim = 0)
         {
             Eigen::Map<Eigen::ArrayXXcf> in_eigen((std::complex<float>*) in.data(), in.extent(0), in.extent(1));
-            auto out_eigen = WireCell::Array::dft_cc(in_eigen, dim);
+
+            // auto out_eigen = WireCell::Array::dft_cc(in_eigen, dim);
+
+            const int nrows = in_eigen.rows();
+            const int ncols = in_eigen.cols();
+
+            Eigen::MatrixXcf out_eigen(nrows, ncols);
+
+            out_eigen = in_eigen.matrix();
+
+            if (dim == 0) {
+                for (int irow = 0; irow < nrows; ++irow) {
+                    Eigen::VectorXcf pspec(ncols);
+                    gEigenFFT_dft_1d.fwd(pspec, out_eigen.row(irow));  // c2c
+                    out_eigen.row(irow) = pspec;
+                }
+            }
+            else {
+                for (int icol = 0; icol < ncols; ++icol) {
+                    Eigen::VectorXcf pspec(nrows);
+                    gEigenFFT_dft_1d.fwd(pspec, out_eigen.col(icol));  // c2c
+                    out_eigen.col(icol) = pspec;
+                }
+            }
+
             auto out = gen_2d_view<array_xxc>(out_eigen.rows(), out_eigen.cols(), 0);
             memcpy( (void*)out.data(), (void*)out_eigen.data(), out_eigen.rows()*out_eigen.cols()*sizeof(Scalar) * 2);
 
@@ -58,7 +110,30 @@ namespace WireCell {
         inline void dft_cc(const array_xxc& in, array_xxc& out, int dim = 0)
         {
             Eigen::Map<Eigen::ArrayXXcf> in_eigen((std::complex<float>*) in.data(), in.extent(0), in.extent(1));
-            auto out_eigen = WireCell::Array::dft_cc(in_eigen, dim);
+
+            // auto out_eigen = WireCell::Array::dft_cc(in_eigen, dim);
+
+            const int nrows = in_eigen.rows();
+            const int ncols = in_eigen.cols();
+
+            Eigen::MatrixXcf out_eigen(nrows, ncols);
+
+            out_eigen = in_eigen.matrix();
+
+            if (dim == 0) {
+                for (int irow = 0; irow < nrows; ++irow) {
+                    Eigen::VectorXcf pspec(ncols);
+                    gEigenFFT_dft_1d.fwd(pspec, out_eigen.row(irow));  // c2c
+                    out_eigen.row(irow) = pspec;
+                }
+            }
+            else {
+                for (int icol = 0; icol < ncols; ++icol) {
+                    Eigen::VectorXcf pspec(nrows);
+                    gEigenFFT_dft_1d.fwd(pspec, out_eigen.col(icol));  // c2c
+                    out_eigen.col(icol) = pspec;
+                }
+            }
             memcpy( (void*)out.data(), (void*)out_eigen.data(), out_eigen.rows()*out_eigen.cols()*sizeof(Scalar) * 2);
 
         }
@@ -66,7 +141,29 @@ namespace WireCell {
         inline array_xxc idft_cc(const array_xxc& in, int dim = 0)
         {
             Eigen::Map<Eigen::ArrayXXcf> in_eigen((std::complex<float>*) in.data(), in.extent(0), in.extent(1));
-            auto out_eigen = WireCell::Array::idft_cc(in_eigen, dim);
+            // auto out_eigen = WireCell::Array::idft_cc(in_eigen, dim);
+            
+            const int nrows = in_eigen.rows();
+            const int ncols = in_eigen.cols();
+
+            // gEigenFFT works on matrices, not arrays, also don't step on const input
+            Eigen::MatrixXcf out_eigen(nrows, ncols);
+            out_eigen = in_eigen.matrix();
+
+            if (dim == 1) {
+                for (int icol = 0; icol < ncols; ++icol) {
+                    Eigen::VectorXcf pspec(nrows);
+                    gEigenFFT_dft_1d.inv(pspec, out_eigen.col(icol));  // c2c
+                    out_eigen.col(icol) = pspec;
+                }
+            }
+            else if (dim == 0) {
+                for (int irow = 0; irow < nrows; ++irow) {
+                    Eigen::VectorXcf pspec(ncols);
+                    gEigenFFT_dft_1d.inv(pspec, out_eigen.row(irow));  // c2c
+                    out_eigen.row(irow) = pspec;
+                }
+            }
             auto out = gen_2d_view<array_xxc>(out_eigen.rows(), out_eigen.cols(), 0);
             memcpy( (void*)out.data(), (void*)out_eigen.data(), out_eigen.rows()*out_eigen.cols()*sizeof(Scalar) * 2);
 
@@ -76,7 +173,29 @@ namespace WireCell {
         inline void  idft_cc(const array_xxc& in, array_xxc& out, int dim = 0)
         {
             Eigen::Map<Eigen::ArrayXXcf> in_eigen((std::complex<float>*) in.data(), in.extent(0), in.extent(1));
-            auto out_eigen = WireCell::Array::idft_cc(in_eigen, dim);
+            // auto out_eigen = WireCell::Array::idft_cc(in_eigen, dim);
+            
+            const int nrows = in_eigen.rows();
+            const int ncols = in_eigen.cols();
+
+            // gEigenFFT works on matrices, not arrays, also don't step on const input
+            Eigen::MatrixXcf out_eigen(nrows, ncols);
+            out_eigen = in_eigen.matrix();
+
+            if (dim == 1) {
+                for (int icol = 0; icol < ncols; ++icol) {
+                    Eigen::VectorXcf pspec(nrows);
+                    gEigenFFT_dft_1d.inv(pspec, out_eigen.col(icol));  // c2c
+                    out_eigen.col(icol) = pspec;
+                }
+            }
+            else if (dim == 0) {
+                for (int irow = 0; irow < nrows; ++irow) {
+                    Eigen::VectorXcf pspec(ncols);
+                    gEigenFFT_dft_1d.inv(pspec, out_eigen.row(irow));  // c2c
+                    out_eigen.row(irow) = pspec;
+                }
+            }
             memcpy( (void*)out.data(), (void*)out_eigen.data(), out_eigen.rows()*out_eigen.cols()*sizeof(Scalar) * 2);
 
         }
@@ -84,7 +203,30 @@ namespace WireCell {
         inline array_xxf idft_cr(const array_xxc& in, int dim = 0)
         {
             Eigen::Map<Eigen::ArrayXXcf> in_eigen((std::complex<float>*) in.data(), in.extent(0), in.extent(1));
-            auto out_eigen = WireCell::Array::idft_cr(in_eigen, dim);
+            // auto out_eigen = WireCell::Array::idft_cr(in_eigen, dim);
+            const int nrows = in_eigen.rows();
+            const int ncols = in_eigen.cols();
+
+            // gEigenFFT works on matrices, not arrays, also don't step on const input
+            Eigen::MatrixXcf partial(nrows, ncols);
+            partial = in_eigen.matrix();
+
+            Eigen::ArrayXXf out_eigen(nrows, ncols);
+
+            if (dim == 0) {
+                for (int irow = 0; irow < nrows; ++irow) {
+                    Eigen::VectorXf wave(ncols);                        // back to real-valued time series
+                    gEigenFFT_dft_c2r_1d.inv(wave, partial.row(irow));  // c2r
+                    out_eigen.row(irow) = wave;
+                }
+            }
+            else if (dim == 1) {
+                for (int icol = 0; icol < ncols; ++icol) {
+                    Eigen::VectorXf wave(nrows);
+                    gEigenFFT_dft_c2r_1d.inv(wave, partial.col(icol));  // c2r
+                    out_eigen.col(icol) = wave;
+                }
+            }
             auto out = gen_2d_view<array_xxf>(out_eigen.rows(), out_eigen.cols(), 0);
             memcpy( (void*)out.data(), (void*)out_eigen.data(), out_eigen.rows()*out_eigen.cols()*sizeof(Scalar));
 
@@ -93,7 +235,30 @@ namespace WireCell {
         inline void idft_cr(const array_xxc& in, array_xxf& out, int dim = 0)
         {
             Eigen::Map<Eigen::ArrayXXcf> in_eigen((std::complex<float>*) in.data(), in.extent(0), in.extent(1));
-            auto out_eigen = WireCell::Array::idft_cr(in_eigen, dim);
+            // auto out_eigen = WireCell::Array::idft_cr(in_eigen, dim);
+            const int nrows = in_eigen.rows();
+            const int ncols = in_eigen.cols();
+
+            // gEigenFFT works on matrices, not arrays, also don't step on const input
+            Eigen::MatrixXcf partial(nrows, ncols);
+            partial = in_eigen.matrix();
+
+            Eigen::ArrayXXf out_eigen(nrows, ncols);
+
+            if (dim == 0) {
+                for (int irow = 0; irow < nrows; ++irow) {
+                    Eigen::VectorXf wave(ncols);                        // back to real-valued time series
+                    gEigenFFT_dft_c2r_1d.inv(wave, partial.row(irow));  // c2r
+                    out_eigen.row(irow) = wave;
+                }
+            }
+            else if (dim == 1) {
+                for (int icol = 0; icol < ncols; ++icol) {
+                    Eigen::VectorXf wave(nrows);
+                    gEigenFFT_dft_c2r_1d.inv(wave, partial.col(icol));  // c2r
+                    out_eigen.col(icol) = wave;
+                }
+            }
             memcpy( (void*)out.data(), (void*)out_eigen.data(), out_eigen.rows()*out_eigen.cols()*sizeof(Scalar));
         }
 

--- a/src/DepoTransform.cxx
+++ b/src/DepoTransform.cxx
@@ -41,8 +41,10 @@
 #include "WireCellGenKokkos/ImpactTransform.h"
 #include "WireCellUtil/NamedFactory.h"
 #include "WireCellIface/IAnodePlane.h"
-#include "WireCellAux/SimpleTrace.h"
-#include "WireCellAux/SimpleFrame.h"
+// #include "WireCellAux/SimpleTrace.h"
+// #include "WireCellAux/SimpleFrame.h"
+#include "WireCellIface/SimpleTrace.h"
+#include "WireCellIface/SimpleFrame.h"
 #include "WireCellGenKokkos/BinnedDiffusion_transform.h"
 #include "WireCellUtil/Units.h"
 #include "WireCellUtil/Point.h"
@@ -55,8 +57,8 @@ WIRECELL_FACTORY(GenKokkosDepoTransform, WireCell::GenKokkos::DepoTransform, Wir
 
 using namespace WireCell;
 using namespace std;
-using WireCell::Aux::SimpleTrace;
-using WireCell::Aux::SimpleFrame;
+// using WireCell::Aux::SimpleTrace;
+// using WireCell::Aux::SimpleFrame;
 
 GenKokkos::DepoTransform::DepoTransform()
   : m_start_time(0.0 * units::ns)

--- a/src/DepoTransform.cxx
+++ b/src/DepoTransform.cxx
@@ -41,8 +41,8 @@
 #include "WireCellGenKokkos/ImpactTransform.h"
 #include "WireCellUtil/NamedFactory.h"
 #include "WireCellIface/IAnodePlane.h"
-#include "WireCellIface/SimpleTrace.h"
-#include "WireCellIface/SimpleFrame.h"
+#include "WireCellAux/SimpleTrace.h"
+#include "WireCellAux/SimpleFrame.h"
 #include "WireCellGenKokkos/BinnedDiffusion_transform.h"
 #include "WireCellUtil/Units.h"
 #include "WireCellUtil/Point.h"
@@ -55,6 +55,8 @@ WIRECELL_FACTORY(GenKokkosDepoTransform, WireCell::GenKokkos::DepoTransform, Wir
 
 using namespace WireCell;
 using namespace std;
+using WireCell::Aux::SimpleTrace;
+using WireCell::Aux::SimpleFrame;
 
 GenKokkos::DepoTransform::DepoTransform()
   : m_start_time(0.0 * units::ns)
@@ -82,7 +84,8 @@ void GenKokkos::DepoTransform::configure(const WireCell::Configuration& cfg)
         auto rng_tn = get<string>(cfg, "rng", "");
         m_rng = Factory::find_tn<IRandom>(rng_tn);
     }
-
+    std::string dft_tn = get<std::string>(cfg, "dft", "FftwDFT");
+    m_dft = Factory::find_tn<IDFT>(dft_tn);
     m_readout_time = get<double>(cfg, "readout_time", m_readout_time);
     m_tick = get<double>(cfg, "tick", m_tick);
     m_start_time = get<double>(cfg, "start_time", m_start_time);
@@ -222,7 +225,7 @@ bool GenKokkos::DepoTransform::operator()(const input_pointer& in, output_pointe
             auto& wires = plane->wires();
 
             auto pir = m_pirs.at(iplane);
-            GenKokkos::ImpactTransform transform(pir, bindiff);
+            GenKokkos::ImpactTransform transform(pir, m_dft, bindiff);
 
            
 	    

--- a/src/ImpactData.cxx
+++ b/src/ImpactData.cxx
@@ -1,5 +1,7 @@
 #include "WireCellGenKokkos/ImpactData.h"
 
+#include "WireCellAux/DftTools.h"
+
 #include <iostream>             // debugging
 
 using namespace WireCell;
@@ -34,7 +36,7 @@ Waveform::compseq_t& GenKokkos::ImpactData::weight_spectrum() const
     return m_weight_spectrum;
 }
 
-void GenKokkos::ImpactData::calculate(int nticks) const
+void GenKokkos::ImpactData::calculate(const IDFT::pointer& dft, int nticks) const
 {
     if (m_waveform.size() > 0) {
         return;
@@ -70,8 +72,8 @@ void GenKokkos::ImpactData::calculate(int nticks) const
         }
     }
 
-    m_spectrum = Waveform::dft(m_waveform);
-    m_weight_spectrum = Waveform::dft(m_weights);
+    m_spectrum = Aux::fwd_r2c(dft, m_waveform);
+    m_weight_spectrum = Aux::fwd_r2c(dft, m_weights);
 }
 
 

--- a/src/ImpactTransform.cxx
+++ b/src/ImpactTransform.cxx
@@ -1,4 +1,7 @@
 #include "WireCellGenKokkos/ImpactTransform.h"
+
+#include "WireCellAux/DftTools.h"
+
 #include "WireCellUtil/Testing.h"
 #include "WireCellUtil/FFTBestLength.h"
 
@@ -13,8 +16,11 @@ double g_fft_time = 0.0;
 using namespace std;
 
 using namespace WireCell;
-GenKokkos::ImpactTransform::ImpactTransform(IPlaneImpactResponse::pointer pir, BinnedDiffusion_transform& bd)
+GenKokkos::ImpactTransform::ImpactTransform(IPlaneImpactResponse::pointer pir,
+                                      const IDFT::pointer& dft,
+                                      BinnedDiffusion_transform& bd)
   : m_pir(pir)
+  , m_dft(dft)
   , m_bd(bd)
   , log(Log::logger("sim"))
   {}
@@ -123,9 +129,8 @@ bool GenKokkos::ImpactTransform::transform_vector()
         m_vec_vec_charge.at(ii).shrink_to_fit();
 
         // Do FFT on time
-        c_data = Array::dft_cc(c_data, 0);
         // Do FFT on wire
-        c_data = Array::dft_cc(c_data, 1);
+        c_data = Aux::fwd(m_dft, c_data);
 
         // std::cout << i << std::endl;
         {
@@ -134,7 +139,7 @@ bool GenKokkos::ImpactTransform::transform_vector()
             {
                 Waveform::compseq_t rs1 = m_vec_map_resp.at(i)[0]->spectrum();
                 // do a inverse FFT
-                Waveform::realseq_t rs1_t = Waveform::idft(rs1);
+                Waveform::realseq_t rs1_t = Aux::inv_c2r(m_dft, rs1);
                 // pick the first xxx ticks
                 Waveform::realseq_t rs1_reduced(m_end_tick - m_start_tick, 0);
                 for (int icol = 0; icol != m_end_tick - m_start_tick; icol++) {
@@ -142,7 +147,7 @@ bool GenKokkos::ImpactTransform::transform_vector()
                     rs1_reduced.at(icol) = rs1_t[icol];
                 }
                 // do a FFT
-                rs1 = Waveform::dft(rs1_reduced);
+                rs1 = Aux::fwd_r2c(m_dft, rs1_reduced);
 
                 for (int icol = 0; icol != m_end_tick - m_start_tick; icol++) {
                     resp_f_w(0, icol) = rs1[icol];
@@ -151,21 +156,21 @@ bool GenKokkos::ImpactTransform::transform_vector()
 
             for (int irow = 0; irow != m_num_pad_wire; irow++) {
                 Waveform::compseq_t rs1 = m_vec_map_resp.at(i)[irow + 1]->spectrum();
-                Waveform::realseq_t rs1_t = Waveform::idft(rs1);
+                Waveform::realseq_t rs1_t = Aux::inv_c2r(m_dft, rs1);
                 Waveform::realseq_t rs1_reduced(m_end_tick - m_start_tick, 0);
                 for (int icol = 0; icol != m_end_tick - m_start_tick; icol++) {
                     if (icol >= int(rs1_t.size())) break;
                     rs1_reduced.at(icol) = rs1_t[icol];
                 }
-                rs1 = Waveform::dft(rs1_reduced);
+                rs1 = Aux::fwd_r2c(m_dft, rs1_reduced);
                 Waveform::compseq_t rs2 = m_vec_map_resp.at(i)[-irow - 1]->spectrum();
-                Waveform::realseq_t rs2_t = Waveform::idft(rs2);
+                Waveform::realseq_t rs2_t = Aux::inv_c2r(m_dft, rs2);
                 Waveform::realseq_t rs2_reduced(m_end_tick - m_start_tick, 0);
                 for (int icol = 0; icol != m_end_tick - m_start_tick; icol++) {
                     if (icol >= int(rs2_t.size())) break;
                     rs2_reduced.at(icol) = rs2_t[icol];
                 }
-                rs2 = Waveform::dft(rs2_reduced);
+                rs2 = Aux::fwd_r2c(m_dft, rs2_reduced);
                 for (int icol = 0; icol != m_end_tick - m_start_tick; icol++) {
                     resp_f_w(irow + 1, icol) = rs1[icol];
                     resp_f_w(end_ch - start_ch - 1 - irow + 2 * npad_wire, icol) = rs2[icol];
@@ -174,13 +179,15 @@ bool GenKokkos::ImpactTransform::transform_vector()
             // std::cout << " vector resp: " << i << " : " << Array::idft_cr(resp_f_w, 0) << std::endl;
 
             // Do FFT on wire for response // slight larger
-            resp_f_w = Array::dft_cc(resp_f_w, 1);  // Now becomes the f and f in both time and wire domain ...
+            // Now becomes the f and f in both time and wire domain ...
+            // resp_f_w = Array::dft_cc(resp_f_w, 1);  
+            resp_f_w = Aux::fwd(m_dft, resp_f_w, 0);
             // multiply them together
             c_data = c_data * resp_f_w;
         }
 
         // Do inverse FFT on wire
-        c_data = Array::idft_cc(c_data, 1);
+        c_data = Aux::inv(m_dft, c_data, 0);
 
         // Add to wire result in frequency
         acc_data_f_w += c_data;
@@ -209,9 +216,11 @@ bool GenKokkos::ImpactTransform::transform_vector()
             m_vec_vec_charge.at(i).shrink_to_fit();
 
             // Do FFT on time
-            data_f_w = Array::dft_rc(data_t_w, 0);
+            // data_f_w = Array::dft_rc(data_t_w, 0);
+            data_f_w = Aux::fwd_r2c(m_dft, data_t_w, 1);
             // Do FFT on wire
-            data_f_w = Array::dft_cc(data_f_w, 1);
+            // data_f_w = Array::dft_cc(data_f_w, 1);
+            data_f_w = Aux::fwd(m_dft, data_f_w, 0);
         }
 
         {
@@ -222,7 +231,7 @@ bool GenKokkos::ImpactTransform::transform_vector()
                 Waveform::compseq_t rs1 = m_vec_map_resp.at(i)[0]->spectrum();
 
                 // do a inverse FFT
-                Waveform::realseq_t rs1_t = Waveform::idft(rs1);
+                Waveform::realseq_t rs1_t = Aux::inv_c2r(m_dft, rs1);
                 // pick the first xxx ticks
                 Waveform::realseq_t rs1_reduced(m_end_tick - m_start_tick, 0);
                 for (int icol = 0; icol != m_end_tick - m_start_tick; icol++) {
@@ -230,7 +239,7 @@ bool GenKokkos::ImpactTransform::transform_vector()
                     rs1_reduced.at(icol) = rs1_t[icol];
                 }
                 // do a FFT
-                rs1 = Waveform::dft(rs1_reduced);
+                rs1 = Aux::fwd_r2c(m_dft, rs1_reduced);
 
                 for (int icol = 0; icol != m_end_tick - m_start_tick; icol++) {
                     resp_f_w(0, icol) = rs1[icol];
@@ -238,21 +247,21 @@ bool GenKokkos::ImpactTransform::transform_vector()
             }
             for (int irow = 0; irow != m_num_pad_wire; irow++) {
                 Waveform::compseq_t rs1 = m_vec_map_resp.at(i)[irow + 1]->spectrum();
-                Waveform::realseq_t rs1_t = Waveform::idft(rs1);
+                Waveform::realseq_t rs1_t = Aux::inv_c2r(m_dft, rs1);
                 Waveform::realseq_t rs1_reduced(m_end_tick - m_start_tick, 0);
                 for (int icol = 0; icol != m_end_tick - m_start_tick; icol++) {
                     if (icol >= int(rs1_t.size())) break;
                     rs1_reduced.at(icol) = rs1_t[icol];
                 }
-                rs1 = Waveform::dft(rs1_reduced);
+                rs1 = Aux::fwd_r2c(m_dft, rs1_reduced);
                 Waveform::compseq_t rs2 = m_vec_map_resp.at(i)[-irow - 1]->spectrum();
-                Waveform::realseq_t rs2_t = Waveform::idft(rs2);
+                Waveform::realseq_t rs2_t = Aux::inv_c2r(m_dft, rs2);
                 Waveform::realseq_t rs2_reduced(m_end_tick - m_start_tick, 0);
                 for (int icol = 0; icol != m_end_tick - m_start_tick; icol++) {
                     if (icol >= int(rs2_t.size())) break;
                     rs2_reduced.at(icol) = rs2_t[icol];
                 }
-                rs2 = Waveform::dft(rs2_reduced);
+                rs2 = Aux::fwd_r2c(m_dft, rs2_reduced);
                 for (int icol = 0; icol != m_end_tick - m_start_tick; icol++) {
                     resp_f_w(irow + 1, icol) = rs1[icol];
                     resp_f_w(end_ch - start_ch - 1 - irow + 2 * npad_wire, icol) = rs2[icol];
@@ -260,19 +269,23 @@ bool GenKokkos::ImpactTransform::transform_vector()
             }
             // std::cout << " vector resp: " << i << " : " << Array::idft_cr(resp_f_w, 0) << std::endl;
             // Do FFT on wire for response // slight larger
-            resp_f_w = Array::dft_cc(resp_f_w, 1);  // Now becomes the f and f in both time and wire domain ...
+            // Now becomes the f and f in both time and wire domain ...
+            // resp_f_w = Array::dft_cc(resp_f_w, 1);
+            resp_f_w = Aux::fwd(m_dft, resp_f_w, 0);
             // multiply them together
             data_f_w = data_f_w * resp_f_w;
         }
 
         // Do inverse FFT on wire
-        data_f_w = Array::idft_cc(data_f_w, 1);
+        // data_f_w = Array::idft_cc(data_f_w, 1);
+        data_f_w = Aux::inv(m_dft, data_f_w, 0);
 
         // Add to wire result in frequency
         acc_data_f_w += data_f_w;
     }
     // m_decon_data = Array::idft_cr(acc_data_f_w, 0); // DEBUG only central
-    acc_data_f_w = Array::idft_cc(acc_data_f_w, 0);  //.block(npad_wire,0,nwires,nsamples);
+    // acc_data_f_w = Array::idft_cc(acc_data_f_w, 0); //.block(npad_wire,0,nwires,nsamples);
+    acc_data_f_w = Aux::inv(m_dft, acc_data_f_w, 1); 
     Array::array_xxf real_m_decon_data = acc_data_f_w.real();
     Array::array_xxf img_m_decon_data = acc_data_f_w.imag().colwise().reverse();
     m_decon_data = real_m_decon_data + img_m_decon_data;
@@ -507,12 +520,12 @@ Waveform::realseq_t GenKokkos::ImpactTransform::waveform(int iwire) const
             wf.resize(nlength, 0);
             Waveform::realseq_t long_resp = m_pir->closest(0)->long_aux_waveform();
             long_resp.resize(nlength, 0);
-            Waveform::compseq_t spec = Waveform::dft(wf);
-            Waveform::compseq_t long_spec = Waveform::dft(long_resp);
+            Waveform::compseq_t spec = Aux::fwd_r2c(m_dft, wf);
+            Waveform::compseq_t long_spec = Aux::fwd_r2c(m_dft, long_resp);
            for (size_t i = 0; i != nlength; i++) {
                 spec.at(i) *= long_spec.at(i);
             }
-            wf = Waveform::idft(spec);
+            wf = Aux::inv_c2r(m_dft, spec);
             wf.resize(nsamples, 0);
          }
 
@@ -549,7 +562,7 @@ KokkosArray::array_xxf GenKokkos::ImpactTransform::waveform_v(int nwires) const
 
            Waveform::realseq_t long_resp = m_pir->closest(0)->long_aux_waveform();
            long_resp.resize(nlength, 0);
-           Waveform::compseq_t long_spec = Waveform::dft(long_resp);
+           Waveform::compseq_t long_spec = Aux::fwd_r2c(m_dft, long_resp);
 	    
      
 	   KokkosArray::array_xc  long_spec_d("long_resp", nlength) ;


### PR DESCRIPTION
 - Use Eigen instead of (WireCell::Array) in KokkosArray_fftw
 - Use IDFT interfaces in several pieces of code
 - wct-sim.jsonnet updated
A rough test with WCT 0.20.0 following [this wiki page](https://github.com/WireCell/wire-cell-gen-kokkos/wiki/Standalone-wire-cell-testing-workflow) looks like this:

![Screen Shot 2022-07-14 at 1 37 27 PM](https://user-images.githubusercontent.com/10383186/179049105-011bc1a1-8a9f-4cb9-8df6-897952894fe5.png)

